### PR TITLE
Changed colors for variables, parameters and properties

### DIFF
--- a/themes/synthwave-x-fluoromachine.json
+++ b/themes/synthwave-x-fluoromachine.json
@@ -177,14 +177,18 @@
       "name": "Language variable",
       "scope": "variable.language",
       "settings": {
-        "foreground": "#8a2dc0",
+        "foreground": "#61e2ff",
         "fontStyle": "bold"
       }
     },
     {
       "name": "Parameter",
-      "scope": "variable.parameter",
+      "scope": [
+        "variable.parameter",
+        "support.type.parameters"
+      ],
       "settings": {
+        "foreground": "#61e2ff",
         "fontStyle": "italic"
       }
     },
@@ -409,7 +413,7 @@
         "support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#8a2dc0"
+        "foreground": "#f92aad"
       }
     },
     {

--- a/themes/synthwave-x-fluoromachine.json
+++ b/themes/synthwave-x-fluoromachine.json
@@ -177,18 +177,14 @@
       "name": "Language variable",
       "scope": "variable.language",
       "settings": {
-        "foreground": "#61e2ff",
+        "foreground": "#8a2dc0",
         "fontStyle": "bold"
       }
     },
     {
       "name": "Parameter",
-      "scope": [
-        "variable.parameter",
-        "support.type.parameters"
-      ],
+      "scope": "variable.parameter",
       "settings": {
-        "foreground": "#61e2ff",
         "fontStyle": "italic"
       }
     },
@@ -413,7 +409,7 @@
         "support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#f92aad"
+        "foreground": "#8a2dc0"
       }
     },
     {

--- a/themes/synthwave-x-fluoromachine.json
+++ b/themes/synthwave-x-fluoromachine.json
@@ -595,6 +595,39 @@
         "foreground": "#61e2ff",
         "fontStyle": "italic"
       }
+    },
+    {
+      "name": "ARM template property name",
+      "scope": [
+        "support.type.property-name.json.arm-template"
+      ],
+      "settings": {
+        "foreground": "#f92aad"
+      }
+    }, 
+    {
+      "name": "ARM template function, parameter and variable names",
+      "scope": [
+        "support.type.parameters.parameter-name.tle.arm-template",
+        "variable.language.variables.variable-name.tle.arm-template",
+        "entity.name.tag.usernamespace.tle.arm-template",
+        "entity.name.tag.userfunction.tle.arm-template"
+      ],
+      "settings": {
+        "foreground": "#61e2ffff",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "ARM template parameters and variables",
+      "scope": [
+        "variable.language.variables.tle.arm-template",
+        "support.type.parameters.tle.arm-template"
+      ],
+      "settings": {
+        "foreground": "#36f9f6ff",
+        "fontStyle": ""
+      }
     }
   ]
 }


### PR DESCRIPTION
When looking at an arm template (which is a type of json file) I saw that almost everything was the default color (#8a2dc0).

I changed so that the property name, variables and parameters have a different look that the default