### PR TITLE
Differentiate objects and object properties

### DIFF
--- a/themes/synthwave-x-fluoromachine.json
+++ b/themes/synthwave-x-fluoromachine.json
@@ -628,6 +628,31 @@
         "foreground": "#36f9f6ff",
         "fontStyle": ""
       }
+    },
+    {
+      "name": "Variable Object and Other Object Property",
+      "scope": [
+        "variable.object.property",
+        "variable.other.object.property"
+      ],
+      "settings": {
+        "foreground": "#b6f0fc"
+      }
+    },
+    {
+      "name": "Variable Other Object Property",
+      "scope": ["variable.other.object.property"],
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Variable Other Object",
+      "scope": ["variable.other.object"],
+      "settings": {
+        "foreground": "#9963ff",
+        "fontStyle": "italic"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Intent

I noticed objects were pretty visually homogeneous and coming from other themes that target variables and properties separately from parent objects, etc. I felt they should be easier to digest at a glance. I tried to replicate that here. I chose one color that you already use and another from FluoroMachine, but feel free to adjust them as needed if you have any interest in this change. I used some pretty general scopes and made up names for the rules - feel free to change them or propose others of course. Lastly, I didn't add glow anywhere, not sure if that's needed or not.

## Result

#### Before:

![image](https://user-images.githubusercontent.com/1288694/82092237-20feb880-96b6-11ea-97e5-1b9be96b891f.png)

#### After:

![image](https://user-images.githubusercontent.com/1288694/82092287-383da600-96b6-11ea-8c70-31f8c7295533.png)

## Disclaimer

I don't know anything about making themes, _and_ I'm colorblind, so take this PR with a grain of salt. 🙂 

Thanks for reviewing.